### PR TITLE
2 bug fix

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -197,7 +197,7 @@ handle_info({stream_close, _Req_id}, State) ->
     shutting_down(State),
     do_close(State),
     do_error_reply(State, closing_on_request),
-    {stop, normal, ok, State};
+    {stop, normal, State};
 
 handle_info({tcp_closed, _Sock}, State) ->    
     do_trace("TCP connection closed by peer!~n", []),


### PR DESCRIPTION
- fix bug when using an ssl socket with socket_options.
  do_setopts/3 was being called with the 3rd arg as a boolean instead of the "State".
- fix crash when requesting to close a stream connection.
