### PR TITLE
No timeout error when there's socket data in the worker's message queue

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -236,10 +236,17 @@ handle_info({req_timedout, From}, State) ->
     end;
 
 handle_info(timeout, State) ->
-    do_trace("Inactivity timeout triggered. Shutting down connection~n", []),
-    shutting_down(State),
-    do_error_reply(State, req_timedout),
-    {stop, normal, State};
+    receive
+        {tcp, _Sock, Data} ->
+            handle_sock_data(Data, State);
+        {ssl, _Sock, Data} ->
+            handle_sock_data(Data, State)
+    after 0 ->
+        do_trace("Inactivity timeout triggered. Shutting down connection~n", []),
+        shutting_down(State),
+        do_error_reply(State, req_timedout),
+        {stop, normal, State}
+    end;
 
 handle_info({trace, Bool}, State) ->
     put(my_trace_flag, Bool),


### PR DESCRIPTION
Hi again Chandru,

If often get req_timedout errors (on a very fast and without congestion Wifi LAN) from a worker.
The handle_info callback receives a timeout messages (set to trigger every time we receive data from the socket) and it shouldn't send the req_timedout error to the caller if there are messages in the queue with socket data (it might have arrived just after the timeout message). The following patch fixes this, however it's a bit ugly since it does a "receive .. -> ... after 0  ... end" trick inside the handle_info clause.

https://github.com/fdmanana/ibrowse/commit/561b34bd73152deb756821d280c24899b378db2a

Probably there's a better solution for this.

Adding an io:format/2 call in handle info like:

io:format("~p timeout~n~nmessages: ~p~n", [self(), element(2, process_info(self(), messages))]),

Often showed me something like this:

<0.415.0> timeout

messages: [{stream_next,{1294,245186,893523}},
           {stream_next,{1294,245186,893523}},
           {stream_next,{1294,245186,893523}},
           {stream_next,{1294,245186,893523}},
           {stream_next,{1294,245186,893523}},
           {tcp,#Port<0.2319>,
                <<"tis lectus dapibus. Quisque non erat lorem. Vivamus posuere imperdiet iaculis. Ut ligula lacus, eleifend at tempor id, auctor eu leo.\n\nDonec mi enim, laoreet pulvinar mollis eu, malesuada viverra nunc. In vitae metus vitae neque tempor dapibus. Maecenas tincidunt purus a felis aliquam placerat. Nulla facilisi. Suspendisse placerat pharetra mattis. Integer tempor malesuada justo at tempus. Maecenas vehicula lorem a sapien bibendum vel iaculis risus feugiat. Pellentesque diam erat, dapibus et pellentesque quis, molestie ut massa. Vivamus iaculis interdum massa id bibendum. Quisque ut mauris dui, sit amet varius elit. Vestibulum elit lorem, rutrum non consectetur ut, laoreet nec nunc. Donec nec mauris ante. Curabitur ut est sed odio pharetra laoreet. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur purus risus, laoreet sed porta id, sagittis vel ipsum. Maecenas nibh diam, cursus et varius sit amet, fringilla sed magna. Nullam id neque eu leo faucibus mollis. Duis nec adipiscing mauris. Suspendisse sollicitudin, enim eu pulvinar commodo, erat augue ultrices mi, a tristique magna sem non libero.\n\nSed in metus nulla. Praesent nec adipiscing sapien. Donec laoreet, velit non rutrum vestibulum, ligula neque adipiscing turpis, at auctor sapien elit ut massa. Nullam aliquam, enim vel posuere rutrum, justo erat laoreet est, vel fringilla lacus nisi non lectus. Etiam lectus nunc, laoreet et placerat at, venenatis quis libero. Praes">>},
           {stream_next,{1294,245186,893523}},
           {tcp,#Port<0.2319>,
                <<"ent in placerat elit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque fringilla augue eu nibh placerat dictum. Nunc porttitor tristique diam, eu aliquam enim aliquet vel. Aliquam lacinia interdum ipsum, in posuere metus luctus vel. Vivamus et nisl a eros semper elementum. Donec venenatis orci at diam tristique sollicitudin. In eu eros sed odio rutrum luctus non nec tellus.\n\nNulla nec felis elit. Nullam in ipsum in ipsum consequat fringilla quis vel tortor. Phasellus non massa nisi, sit amet aliquam urna. Sed fermentum nibh vitae lacus tincidunt nec tincidunt massa bibendum. Etiam elit dui, facilisis sit amet vehicula nec, iaculis at sapien. Ut at massa id dui ultrices volutpat ut ac libero. Fusce ipsum mi, bibendum a lacinia et, pulvinar eget mauris. Proin faucibus urna ut lorem elementum vulputate. Duis quam leo, malesuada non euismod ut, blandit facilisis mauris. Suspendisse sit amet magna id velit tincidunt aliquet nec eu dolor. Curabitur bibendum lorem vel felis tempus dapibus. Aliquam erat volutpat. Aenean cursus tortor nec dui aliquet porta. Aenean commodo iaculis suscipit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Quisque sit amet ornare elit. Nam ligula risus, vestibulum nec mattis in, condimentum ac ante. Donec fringilla, justo et ultrices faucibus, tellus est volutpat massa, vitae commodo sapien diam non risus. Vivamus at arc">>}]

What do you think?

cheers
