### PR TITLE
Stream next reset inac timer

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -335,7 +335,7 @@ handle_sock_data(Data, #state{status           = get_body,
                         cancel_timer(State_2#state.inactivity_timer_ref, {eat_message, timeout}),
                         {noreply, State_2#state{inactivity_timer_ref = undefined}};
                     _ ->
-                        {no_reply, set_inac_timer(State_2)}
+                        {noreply, set_inac_timer(State_2)}
                     end;
                 State_1 ->
                     active_once(State_1),


### PR DESCRIPTION
Hi Chandru,

The following one line patch fixes the timeout issues I told you I have when using may workers with the {stream_to, {Pid(), once}} option on a local and fast network.

Let me know if you agree with it.

regards,
Filipe Manana
