### PR TITLE
save_response_to_file option extended to support appending to an existing file

### DIFF
--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -286,7 +286,7 @@ send_req(Url, Headers, Method, Body) ->
 %% Sock_opts = [Sock_opt]
 %% Sock_opt = term()
 %% ChunkSize = integer()
-%% srtf() = boolean() | filename()
+%% srtf() = boolean() | filename() | {append, filename()}
 %% filename() = string()
 %% response_format() = list | binary
 send_req(Url, Headers, Method, Body, Options) ->

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -357,7 +357,8 @@ accumulate_response(Data,
                                          tmp_file_fd = undefined} = CurReq,
                       http_status_code=[$2 | _]}=State) when Srtf /= false ->
     TmpFilename = make_tmp_filename(Srtf),
-    case file:open(TmpFilename, [write, delayed_write, raw]) of
+    Mode = file_mode(Srtf),
+    case file:open(TmpFilename, [Mode, delayed_write, raw]) of
         {ok, Fd} ->
             accumulate_response(Data, State#state{
                                         cur_req = CurReq#request{
@@ -434,7 +435,12 @@ make_tmp_filename(true) ->
                    integer_to_list(B) ++
                    integer_to_list(C)]);
 make_tmp_filename(File) when is_list(File) ->
+    File;
+make_tmp_filename({append, File}) when is_list(File) ->
     File.
+
+file_mode({append, _File}) -> append;
+file_mode(_Srtf) -> write.
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
I needed to resume file downloads in my application, so I added `{append, filename()}` as a legal `save_response_to_file` value.
