### PR TITLE
Fix vsn() handling for rebar

### DIFF
--- a/src/ibrowse.app.src
+++ b/src/ibrowse.app.src
@@ -1,6 +1,6 @@
 {application, ibrowse,
         [{description, "HTTP client application"},
-         {vsn, "2.1.3"},
+         {vsn, git},
          {modules, [ ibrowse, 
 		     ibrowse_http_client, 
 		     ibrowse_app, 


### PR DESCRIPTION
Hi there, I noticed an error when I tried to check out ibrowse using rebar.  I checked out the tag v2.2.0, but rebar complained because the app vsn() states that it's 2.1.3.

This fix tells rebar to use the version specified in the latest git tag, now it should never get out-of-date!
