### PR TITLE
Remove direct dependency on sasl

### DIFF
--- a/src/ibrowse.app.src
+++ b/src/ibrowse.app.src
@@ -8,6 +8,6 @@
 		     ibrowse_lib,
 		     ibrowse_lb ]},
          {registered, []},
-         {applications, [kernel,stdlib,sasl]},
+         {applications, [kernel,stdlib]},
 	 {env, []},
 	 {mod, {ibrowse_app, []}}]}.


### PR DESCRIPTION
I like to use lager for my logger, but listing sasl as a dependency in the .app file loads sasl. There are better options for application developers to invoke sasl or lager themselves when they package their application.
