### PR TITLE
Using project version in the OTP app file, to fix rebar dep issue

### DIFF
--- a/src/ibrowse.app.src
+++ b/src/ibrowse.app.src
@@ -1,6 +1,6 @@
 {application, ibrowse,
         [{description, "HTTP client application"},
-         {vsn, git},
+         {vsn, "2.2.0"},
          {modules, [ ibrowse, 
 		     ibrowse_http_client, 
 		     ibrowse_app, 


### PR DESCRIPTION
Hiya, this is a very simple commit: it puts the project's version (currently "2.2.0") in the src/ibrowse.app.src file, replacing the atom 'git' that was there before. Before this change, attempts to name ibrowse as a dependency in another project caused rebar to fall over and die in the 'get-deps' command, since it was trying to pass that atom as a string to the RE engine. After this change, my projects can depend on ibrowse as I please. :-)
