### PR TITLE
make ssl_options default to []

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -613,7 +613,8 @@ check_ssl_options(Options, State) ->
         false ->
             State;
         true ->
-            State#state{is_ssl=true, ssl_options=get_value(ssl_options, Options)}
+            State#state{is_ssl=true, ssl_options=get_value(ssl_options,
+                    Options, [])}
     end.
 
 send_req_1(From,


### PR DESCRIPTION
If someone set is_ssl to true but don't pass any ssl_options , then it will default to false and create a badarg error later.
