### PR TITLE
Ibrowse_lb process shuts down before all the connections are closed.

### DIFF
--- a/src/ibrowse_lb.erl
+++ b/src/ibrowse_lb.erl
@@ -173,14 +173,13 @@ handle_info({'EXIT', Pid, _Reason},
 		   ets_tid = Tid} = State) ->
     ets:match_delete(Tid, {{'_', Pid}, '_'}),
     Cur_1 = Cur - 1,
-    State_1 = case Cur_1 of
+    case Cur_1 of
 		  0 ->
 		      ets:delete(Tid),
-		      State#state{ets_tid = undefined};
+			  {noreply, State#state{ets_tid = undefined, num_cur_sessions = 0}, 10000};
 		  _ ->
-		      State
-	      end,
-    {noreply, State_1#state{num_cur_sessions = Cur_1}, 10000};
+		      {noreply, State#state{num_cur_sessions = Cur_1}}
+	      end;
 
 handle_info({trace, Bool}, #state{ets_tid = undefined} = State) ->
     put(my_trace_flag, Bool),


### PR DESCRIPTION
I encountered this issue in the following scenario:
1. Request details of resource with HEAD request.
2. If 404, upload file with chunked encoding.

What happens is the that the connection for the HEAD request will timeout after receiving its reply, closing the pipeline and 'EXIT'ing. This is caught by the ibrowse_lb process (line 171), resulting in it removing it from the ets table, and settings a gen_server timeout of 10000.  After this expires (line 198) the ibrowse_lb process will start a timer to send itself the shutdown atom and complete the shutdown.

If a connection is still open, for a long upload, the ets table that it is using is destroyed resulting in a error when the connection process finally completes and it tries to increment the pipeline counter (ibrowse_http_client:1798).

Fix is to only start the timeout when we know we have 0 ongoing sessions.
