### PR TITLE
Returning empty bodies from the body generating function results in the end of the resource.

### DIFF
--- a/rebar.bat
+++ b/rebar.bat
@@ -1,4 +1,0 @@
-@echo off
-setlocal
-set rebarscript=%~f0
-"C:\Program Files (x86)\erl5.8.4\bin\escript.exe" "%rebarscript:.bat=%" %*


### PR DESCRIPTION
If nothing is returned from the body generating function, a chunk with: "0\r\n\r\n" gets sent resulting in the server interpreting it as the end of the entity, which it shouldn't be. I guess it really comes down to semantics because really only a eof should generate the final chunk.

The commit pattern matches for empty bodies and loops again without sending anything.

I encountered this when compressing data and not every loop would return data. I don't know if it needs to be documented that returning nothing triggers the eof behaviour or if a patch like this is necessary.
