### PR TITLE
Allow missing Content-Length for 303 response. 

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -1091,8 +1091,7 @@ parse_response(Data, #state{reply_buffer = Acc, reqs = Reqs,
                     parse_response(Data_1, State_1#state{recvd_headers = [],
                                                          status = get_header});
                 _ when StatCode =:= "204";
-                       StatCode =:= "304";
-                       StatCode =:= "303" ->
+                       StatCode =:= "304" ->
                     %% No message body is expected for these Status Codes.
                     %% RFC2616 - Sec 4.4
                     {_, Reqs_1} = queue:out(Reqs),
@@ -1121,6 +1120,25 @@ parse_response(Data, #state{reply_buffer = Acc, reqs = Reqs,
                                ConnClose =:= "close" ->
                     send_async_headers(ReqId, StreamTo, Give_raw_headers, State_1),
                     State_1#state{reply_buffer = Data_1};
+                undefined when StatCode =:= "303" ->
+                    %% Some servers send 303 requests without a body.
+                    %% RFC2616 says that they SHOULD, but they dont.
+                    case ibrowse:get_config_value(allow_303_with_no_body, false) of
+                      false -> 
+                        fail_pipelined_requests(State_1,
+                                            {error, {content_length_undefined,
+                                                     {stat_code, StatCode}, Headers}}),
+                       {error, content_length_undefined};
+                      true -> 
+                        {_, Reqs_1} = queue:out(Reqs),
+                        send_async_headers(ReqId, StreamTo, Give_raw_headers, State_1),
+                        State_1_1 = do_reply(State_1, From, StreamTo, ReqId, Resp_format,
+                                             {ok, StatCode, Headers_1, []}),
+                        cancel_timer(T_ref, {eat_message, {req_timedout, From}}),
+                        State_2 = reset_state(State_1_1),
+                        State_3 = set_cur_request(State_2#state{reqs = Reqs_1}),
+                        parse_response(Data_1, State_3)
+                    end;
                 undefined ->
                     fail_pipelined_requests(State_1,
                                             {error, {content_length_undefined,

--- a/test/ibrowse_test_server.erl
+++ b/test/ibrowse_test_server.erl
@@ -159,6 +159,18 @@ process_request(Sock, Sock_type,
                          uri = {abs_path, "/ibrowse_head_test"}}) ->
     Resp = <<"HTTP/1.1 200 OK\r\nServer: Apache-Coyote/1.1\r\nTransfer-Encoding: chunked\r\nDate: Wed, 04 Apr 2012 16:53:49 GMT\r\nConnection: close\r\n\r\n">>,
     do_send(Sock, Sock_type, Resp);
+process_request(Sock, Sock_type,
+                #request{method='POST',
+                         headers = _Headers,
+                         uri = {abs_path, "/ibrowse_303_no_body_test"}}) ->
+    Resp = <<"HTTP/1.1 303 See Other\r\nLocation: http://example.org\r\n">>,
+    do_send(Sock, Sock_type, Resp);
+process_request(Sock, Sock_type,
+                #request{method='POST',
+                         headers = _Headers,
+                         uri = {abs_path, "/ibrowse_303_with_body_test"}}) ->
+    Resp = <<"HTTP/1.1 303 See Other\r\nLocation: http://example.org\r\nContent-Length: 5\r\n\r\nabcde">>,
+    do_send(Sock, Sock_type, Resp);
 process_request(Sock, Sock_type, Req) ->
     do_trace("Recvd req: ~p~n", [Req]),
     Resp = <<"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n">>,


### PR DESCRIPTION
I have encountered a problem where servers send a 303 with no Content-Length and no body. This causes a content_length_undefined error to occur.

The RFC says they SHOULD contain an explanation in the body, not MUST. For HTTP APIs It seems reasonable to expect that a redirect response may not contain a body and the client just uses the Location header to proceed.
