### PR TITLE
Return lowercase response header names

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -1046,7 +1046,7 @@ parse_response(Data, #state{reply_buffer = Acc, reqs = Reqs,
                                             raw_headers = Raw_headers,
                                             http_status_code=StatCode};
                           false ->
-                              State_0#state{recvd_headers=Headers_1, status=get_body,
+                              State_0#state{recvd_headers=LCHeaders, status=get_body,
                                             reply_buffer = <<>>,
                                             http_status_code=StatCode}
                       end,


### PR DESCRIPTION
Unless the `give_raw_headers` option is specified, we return all
response header names in lowercase.

This makes it easier to lookup response header values.  Now, one can
simply call `proplists:get_value/2`, for instance, without having to
first canonicalize the response header names.
