### PR TITLE
Retry requests when the worker has the connection close

### DIFF
--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -443,6 +443,8 @@ do_send_req(Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout) ->
             {error, sel_conn_closed};
         {'EXIT', {normal, _}} ->
             {error, req_timedout};
+        {'EXIT', {connection_closed, _}} ->
+            {error, sel_conn_closed};
         {error, connection_closed} ->
             {error, sel_conn_closed};
         {'EXIT', Reason} ->

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -215,11 +215,11 @@ handle_info({stream_close, _Req_id}, State) ->
 handle_info({tcp_closed, _Sock}, State) ->
     do_trace("TCP connection closed by peer!~n", []),
     handle_sock_closed(State),
-    {stop, normal, State};
+    {stop, connection_closed, State};
 handle_info({ssl_closed, _Sock}, State) ->
     do_trace("SSL connection closed by peer!~n", []),
     handle_sock_closed(State),
-    {stop, normal, State};
+    {stop, connection_closed, State};
 
 handle_info({tcp_error, _Sock, Reason}, State) ->
     do_trace("Error on connection to ~1000.p:~1000.p -> ~1000.p~n",


### PR DESCRIPTION
When a tcp_closed or ssl_closed message is handled while ibrowse is
trying to send a request to a worker, ibrowse would incorrectly return a
req_timedout message, when, in fact, the request had not even been
handled.

This patch attempts to avoid that race condition by signalling tcp or
ssl closed messages back to ibrowse differently than a normal exit.

I don't know if this is the right way to fix this, or if tcp_error and ssl_error need a similar patch, but it made the race condition stop.
