### PR TITLE
ibrowse_socks5: fix 'can't find include lib "kernel/src/inet_dns.hrl"'

### DIFF
--- a/src/ibrowse_socks5.erl
+++ b/src/ibrowse_socks5.erl
@@ -1,7 +1,5 @@
 -module(ibrowse_socks5).
 
--include_lib("kernel/src/inet_dns.hrl").
-
 -export([connect/3]).
 
 -define(TIMEOUT, 2000).


### PR DESCRIPTION
This commit should fix the 'can't find include lib "kernel/src/inet_dns.hrl"' issue, because we will not use internal header files. Also this commit removes some hardcode ( -define(DNS_IP, {8,8,8,8}) ) and uses a convenient way to get a host IP address.

P.S. I didn't test it because I haven't a socks5 proxy.
