### PR TITLE
Fix failing requests when ibrowse_lb process does not stop gracefully.

### DIFF
--- a/src/ibrowse_lb.erl
+++ b/src/ibrowse_lb.erl
@@ -216,7 +216,10 @@ handle_info(_Info, State) ->
 %% Description: Shutdown the server
 %% Returns: any (ignored by gen_server)
 %%--------------------------------------------------------------------
-terminate(_Reason, _State) ->
+terminate(_Reason, #state{host = Host, port = Port}) ->
+    % Use delete_object instead of delete in case another process for this host/port
+    % has been spawned, in which case will be deleting the wrong record because pid won't match.
+    ets:delete_object(ibrowse_lb, #lb_pid{host_port = {Host, Port}, pid = self()}),
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This behavior can be simulated in the current codebase by calling

``` erlang
ibrowse_lb:stop(Pid)
```

where `Pid` is one of the currently running `ibrowse_lb` processes.  If the process is stopped at the right time, running `ets:tab2list(ibrowse_lb)` will confirm that the process record is still in the table, which would make `ibrowse`send `spawn_connection` messages to a process that does not exist.

`ibrowse` does not recover from this condition automatically.
