### PR TITLE
Build under R18 #129

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -433,7 +433,7 @@ accumulate_response(Data, #state{reply_buffer      = RepBuf,
 
 make_tmp_filename(true) ->
     DownloadDir = ibrowse:get_config_value(download_dir, filename:absname("./")),
-    {A,B,C} = now(),
+    {A,B,C} = os:timestamp(),
     filename:join([DownloadDir,
                    "ibrowse_tmp_file_"++
                    integer_to_list(A) ++
@@ -1923,7 +1923,12 @@ cancel_timer(Ref, {eat_message, Msg}) ->
     end.
 
 make_req_id() ->
-    now().
+    case catch erlang:unqiue_integer() of
+        {'EXIT', _} ->
+            erlang:apply(erlang, now, []);
+        V ->
+            V
+    end.
 
 to_lower(Str) when is_binary(Str) ->
     to_lower(binary_to_list(Str));

--- a/src/ibrowse_lib.erl
+++ b/src/ibrowse_lib.erl
@@ -369,7 +369,7 @@ default_port(ftp)   -> 21.
 
 printable_date() ->
     {{Y,Mo,D},{H, M, S}} = calendar:local_time(),
-    {_,_,MicroSecs} = now(),
+    {_,_,MicroSecs} = os:timestamp(),
     [integer_to_list(Y),
      $-,
      integer_to_list(Mo),

--- a/test/ibrowse_test.erl
+++ b/test/ibrowse_test.erl
@@ -86,7 +86,7 @@ load_test(Url, NumWorkers, NumReqsPerWorker) when is_list(Url),
     proc_lib:spawn(?MODULE, send_reqs_1, [Url, NumWorkers, NumReqsPerWorker]).
 
 send_reqs_1(Url, NumWorkers, NumReqsPerWorker) ->
-    Start_time = now(),
+    Start_time = os:timestamp(),
     ets:new(pid_table, [named_table, public]),
     ets:new(ibrowse_test_results, [named_table, public]),
     ets:new(ibrowse_errors, [named_table, public, ordered_set]),
@@ -96,7 +96,7 @@ send_reqs_1(Url, NumWorkers, NumReqsPerWorker) ->
     spawn_workers(Url, NumWorkers, NumReqsPerWorker),
     log_msg("Finished spawning workers...~n", []),
     do_wait(Url),
-    End_time = now(),
+    End_time = os:timestamp(),
     log_msg("All workers are done...~n", []),
     log_msg("ibrowse_test_results table: ~n~p~n", [ets:tab2list(ibrowse_test_results)]),
     log_msg("Start time: ~1000.p~n", [calendar:now_to_local_time(Start_time)]),
@@ -174,7 +174,7 @@ do_send_req_1(Url, NumReqs) ->
 	{error, retry_later} ->
 	    ets:update_counter(ibrowse_test_results, retry_later, 1);
 	Err ->
-	    ets:insert(ibrowse_errors, {now(), Err}),
+	    ets:insert(ibrowse_errors, {os:timestamp(), Err}),
 	    ets:update_counter(ibrowse_test_results, other_error, 1),
 	    ok
     end,
@@ -185,7 +185,7 @@ dump_errors() ->
 	0 ->
 	    ok;
 	_ ->
-	    {A, B, C} = now(),
+	    {A, B, C} = os:timestamp(),
 	    Filename = lists:flatten(
 			 io_lib:format("ibrowse_errors_~p_~p_~p.txt" , [A, B, C])),
 	    case file:open(Filename, [write, delayed_write, raw]) of


### PR DESCRIPTION
I do `erlang:apply(erlang, now, [])` because `now()` throws error during compile on R18