### PR TITLE
Proper lager usage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
-{erl_opts, [debug_info, warnings_as_errors, warn_unused_vars, nowarn_shadow_vars, warn_unused_import]}.
+{erl_opts, [debug_info, {parse_transform, lager_transform}, warnings_as_errors, warn_unused_vars, nowarn_shadow_vars, warn_unused_import]}.
 {xref_checks, [undefined_function_calls, deprecated_function_calls]}.
 {eunit_opts, [verbose]}.


### PR DESCRIPTION
Using lager:something(...) isn't possible w/o parse_transform. It must be added either into every erl-file or externally, into rebar.config (I prefer the latter option). So let's add it.

It wasn't detected previously since all lager invocations are quarded by catch clauses.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>