### PR TITLE
socks5 + ssl

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -570,7 +570,19 @@ do_connect(Host, Port, Options, #state{is_ssl      = true,
                                        use_proxy   = false,
                                        ssl_options = SSLOptions},
            Timeout) ->
-    ssl:connect(Host, Port, get_sock_options(Host, Options, SSLOptions), Timeout);
+    Socks5Host = get_value(socks5_host, Options, undefined),
+    Sock_options = get_sock_options(Host, Options, []),
+    catch case Socks5Host of
+      undefined ->
+        ssl:connect(Host, Port, get_sock_options(Host, Options, SSLOptions), Timeout);
+      _ ->
+        case ibrowse_socks5:connect(Host, Port, Options, Sock_options, Timeout) of
+          {ok, Socket} -> 
+            ssl:connect(Socket, get_sock_options(Host, Options, SSLOptions), Timeout);
+          Else ->
+            Else
+        end
+    end;
 do_connect(Host, Port, Options, _State, Timeout) ->
     Socks5Host = get_value(socks5_host, Options, undefined),
     Sock_options = get_sock_options(Host, Options, []),


### PR DESCRIPTION
**The problem:** socks5 proxy settings ignored for SSL connections.

**Example:** next request 
`ibrowse:send_req("http://www.google.com",[], get, [], [{socks5_host, "127.0.0.1"}, {socks5_port, 12345}])`
will be send through proxy 127.0.0.1: 12345 as expected. But the same  HTTPS request
`ibrowse:send_req("https://www.google.com",[], get, [], [{socks5_host, "127.0.0.1"}, {socks5_port, 12345}])`
will be send directly to www.google.com

**Decision:** this commit upgrades socks5 proxy connection to SSL connection if needed.