### PR TITLE
Add address family for inet:gethostbyname/2 call

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -619,7 +619,7 @@ is_ipv6_host(Host) ->
         {ok, {_, _, _, _}} ->
             false;
         _  ->
-            case inet:gethostbyname(Host) of
+            case inet:gethostbyname(Host, inet6) of
                 {ok, #hostent{h_addrtype = inet6}} ->
                     true;
                 _ ->


### PR DESCRIPTION
I was wondering why ibrowse was unable to complete a get request to an IPv6-only host:
```
> ibrowse:send_req("http://ipv6.helios.click", [], get).
{error,{conn_failed,{error,nxdomain}}}
```
Turns out the function [is_ipv6_host/1](https://github.com/cmullaparthi/ibrowse/blob/7529807170cf3c8f6a8c5c95526e670420ff591b/src/ibrowse_http_client.erl#L622) returns `false`, although the domain has an AAAA record set. The problem is that it calls `inet:gethostbyname/1`, which will use IPv6 only if `inet_db:res_option(inet6)` is set to `true`. By default, this setting is set to false (see the [Erlang repository](https://github.com/erlang/otp/blob/698068c2322d6032f46487f56802246198e576f2/lib/kernel/src/inet_db.erl#L882))

I'm wondering if this is intended behavior, or if it is a bug, because as of now, IPv6 hosts are not resolved correctly if the standard setting is used. If it is a bug, this PR should fix it.