### PR TITLE
added a function to set the download_dir in the internal config ets

### DIFF
--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -91,6 +91,7 @@
          set_max_sessions/3,
          set_max_pipeline_size/3,
          set_max_attempts/3,
+         set_download_dir/1,
          set_dest/3,
          trace_on/0,
          trace_off/0,
@@ -486,6 +487,11 @@ set_max_pipeline_size(Host, Port, Max) when is_integer(Max), Max > 0 ->
 %% @spec set_max_attempts(Host::string(), Port::integer(), Max::integer()) -> ok
 set_max_attempts(Host, Port, Max) when is_integer(Max), Max > 0 ->
     gen_server:call(?MODULE, {set_config_value, {max_attempts, Host, Port}, Max}).
+
+%% @doc set the download directory where the files are stored
+%% @spec set_download_dir(Dir::string()) -> ok
+set_download_dir(Dir) -> 
+    gen_server:call(?MODULE, {set_config_value, download_dir, Dir}).
 
 do_send_req(Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout) ->
     case catch ibrowse_http_client:send_req(Conn_Pid, Parsed_url,


### PR DESCRIPTION
when you read the config key download_dir you read it from your own configuration and not from the application env var as described in the documentation.

"The directory to download to can be set using the application env var download_dir - the default is the current working directory:"

I added a function to the browse module, so you are able to set the download_dir in the browse config ets and with this change the read of the config key download_dir work.