### PR TITLE
Increase timeout in pipelining test

### DIFF
--- a/test/ibrowse_tests.erl
+++ b/test/ibrowse_tests.erl
@@ -15,7 +15,7 @@
 -define(BASE_URL, "http://localhost:" ++ integer_to_list(?SERVER_PORT)).
 -define(SHORT_TIMEOUT_MS, 5000).
 -define(LONG_TIMEOUT_MS, 30000).
--define(PAUSE_FOR_CONNECTIONS_MS, 2000).
+-define(PAUSE_FOR_CONNECTIONS_MS, 4000).
 
 %%-compile(export_all).
 


### PR DESCRIPTION
In CouchDB's CI the small_pipeline test intermittently fails with something like:

```
in function ibrowse_tests:'-small_pipeline/0-fun-5-'/1 (test/ibrowse_tests.erl, line 150)
  {line,150},
  {expression,"Counts"},
  {expected,"\n\n\n\n\n\n\n\n\n\n"},
  {value,"\n\n\n\n\n\n\n\n\t\n"}]}
```

Increasing the timeout a bit seems to help in local tests.