### PR TITLE
Add `format_status(Status)` callback function

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 	   warn_unused_import
 	   ]}.
 % rebar 2
-{require_min_otp_vsn, "25"},
+{require_min_otp_vsn, "25"}.
 % rebar 3
 {minimum_otp_vsn, "25"}.
 {xref_checks, [undefined_function_calls, deprecated_function_calls]}.

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -33,7 +33,8 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3
+         code_change/3,
+         format_status/1
         ]).
 
 -include("ibrowse.hrl").
@@ -322,8 +323,60 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %%--------------------------------------------------------------------
+%% Function: format_status/1
+%% Purpose: Clean process state before logging
+%% Returns: #{state => ScrubbedState}
+%%--------------------------------------------------------------------
+format_status(Status) ->
+    maps:map(
+        fun
+            (state, State) ->
+                #state{
+                    reqs = Reqs,
+                    reply_buffer = ReplyBuf,
+                    recvd_headers = RCVDHeaders,
+                    raw_headers = RawHeaders,
+                    chunk_size_buffer = ChunkSizeBuf,
+                    cur_req = Request
+                } = State,
+                Scrubbed = State#state{
+                    reqs = {queue_length, queue:len(Reqs)},
+                    reply_buffer = {byte_size, get_size(ReplyBuf)},
+                    recvd_headers = lists:map(fun({K, _V}) -> K end, RCVDHeaders),
+                    raw_headers = {byte_size, get_size(RawHeaders)},
+                    chunk_size_buffer = {byte_size, get_size(ChunkSizeBuf)},
+                    cur_req = scrub_req(Request)
+                },
+                maps:from_list(
+                    lists:zip(
+                        record_info(fields, state),
+                        tl(tuple_to_list(Scrubbed))
+                    )
+                );
+            (_, Value) ->
+                Value
+        end,
+        Status
+    ).
+
+%%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
+get_size(RawData) when is_binary(RawData) ->
+    byte_size(RawData);
+get_size(_) ->
+    0.
+
+scrub_req(#request{} = Req) ->
+    Req#request{url = url_strip_password(Req#request.url)};
+scrub_req(Other) ->
+    Other.
+
+url_strip_password(Url) ->
+    re:replace(Url,
+        "(http|https|socks5)://([^:]+):[^@]+@(.*)$",
+        "\\1://\\2:*****@\\3",
+        [{return, list}]).
 
 %%--------------------------------------------------------------------
 %% Handles data recvd on the socket


### PR DESCRIPTION
Add [`format_status/1`](https://www.erlang.org/doc/apps/stdlib/gen_server.html#c:format_status/1) callback function to remove sensitive data from status for debugging and logging.