### PR TITLE
Add binary optimization to chunk_request_body

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -19,7 +19,8 @@
          start/1,
          start/2,
          stop/1,
-         send_req/7
+         send_req/7,
+         chunk_request_body/2
         ]).
 
 -ifdef(debug).
@@ -1220,32 +1221,35 @@ chunk_request_body(Body, _ChunkSize) when is_tuple(Body) orelse
 chunk_request_body(Body, ChunkSize) ->
     chunk_request_body(Body, ChunkSize, []).
 
-chunk_request_body(Body, _ChunkSize, Acc) when Body == <<>>; Body == [] ->
+chunk_request_body(Body, ChunkSize, Acc) when is_binary(Body) ->
+    chunk_binary_body(Body, ChunkSize, Acc);
+chunk_request_body([], _ChunkSize, Acc) ->
     LastChunk = "0\r\n",
     lists:reverse(["\r\n", LastChunk | Acc]);
-chunk_request_body(Body, ChunkSize, Acc) when is_binary(Body),
-                                              size(Body) >= ChunkSize ->
-    <<ChunkBody:ChunkSize/binary, Rest/binary>> = Body,
-    Chunk = [?dec2hex(ChunkSize),"\r\n",
-             ChunkBody, "\r\n"],
-    chunk_request_body(Rest, ChunkSize, [Chunk | Acc]);
-chunk_request_body(Body, _ChunkSize, Acc) when is_binary(Body) ->
-    BodySize = size(Body),
-    Chunk = [?dec2hex(BodySize),"\r\n",
-             Body, "\r\n"],
-    LastChunk = "0\r\n",
-    lists:reverse(["\r\n", LastChunk, Chunk | Acc]);
 chunk_request_body(Body, ChunkSize, Acc) when length(Body) >= ChunkSize ->
     {ChunkBody, Rest} = split_list_at(Body, ChunkSize),
-    Chunk = [?dec2hex(ChunkSize),"\r\n",
-             ChunkBody, "\r\n"],
+    Chunk = [?dec2hex(ChunkSize),"\r\n", ChunkBody, "\r\n"],
     chunk_request_body(Rest, ChunkSize, [Chunk | Acc]);
 chunk_request_body(Body, _ChunkSize, Acc) when is_list(Body) ->
     BodySize = length(Body),
-    Chunk = [?dec2hex(BodySize),"\r\n",
-             Body, "\r\n"],
+    Chunk = [?dec2hex(BodySize),"\r\n", Body, "\r\n"],
     LastChunk = "0\r\n",
     lists:reverse(["\r\n", LastChunk, Chunk | Acc]).
+
+chunk_binary_body(Body, ChunkSize, Acc) ->
+    case Body of
+        <<ChunkBody:ChunkSize/binary, Rest/binary>> ->
+            Chunk = [?dec2hex(ChunkSize),"\r\n", ChunkBody, "\r\n"],
+            chunk_binary_body(Rest, ChunkSize, [Chunk | Acc]);
+        <<>> ->
+            LastChunk = "0\r\n",
+            lists:reverse(["\r\n", LastChunk | Acc]);
+        _ ->
+            BodySize = byte_size(Body),
+            Chunk = [?dec2hex(BodySize),"\r\n", Body, "\r\n"],
+            LastChunk = "0\r\n",
+            lists:reverse(["\r\n", LastChunk, Chunk | Acc])
+    end.
 
 
 parse_response(<<>>, #state{cur_req = undefined}=State) ->

--- a/test/ibrowse_test.erl
+++ b/test/ibrowse_test.erl
@@ -38,6 +38,7 @@
          test_connect_to_unreachable_fails/0,
          test_connect_to_preserves_host_header/0,
          test_dead_lb_pid/0,
+         test_chunk_request_body/0,
          test_generate_body_0/0,
          test_retry_of_requests/0,
          test_retry_of_requests/1,
@@ -69,6 +70,7 @@
                       {local_test_fun, test_connect_to_unreachable_fails, []},
                       {local_test_fun, test_connect_to_preserves_host_header, []},
                       {local_test_fun, test_dead_lb_pid, []},
+                      {local_test_fun, test_chunk_request_body, []},
                       {local_test_fun, test_retry_of_requests, []},
 		      {local_test_fun, verify_chunked_streaming, []},
 		      {local_test_fun, test_chunked_streaming_once, []},
@@ -950,6 +952,41 @@ test_dead_lb_pid() ->
     true = NewPid /= Pid,
     true = is_process_alive(NewPid),
     success.
+
+%%------------------------------------------------------------------------------
+%% Test chunk request body encoding. We exported the function from the module
+%% to run it through these tests
+%%------------------------------------------------------------------------------
+
+% Helper
+chunk_body(Body, N) ->
+    ibrowse_http_client:chunk_request_body(Body, N).
+
+test_chunk_request_body() ->
+    Zero = <<"0\r\n\r\n">>,
+    Cases = [
+             {<<Zero/binary>>,                                            <<>>,               1024},
+             {<<Zero/binary>>,                                            [],                 1024},
+             {<<"5\r\nhello\r\n", Zero/binary>>,                          <<"hello">>,        1024},
+             {<<"5\r\nhello\r\n", Zero/binary>>,                          "hello",            1024},
+             {<<"5\r\nhello\r\n", Zero/binary>>,                          <<"hello">>,        5},
+             {<<"5\r\nhello\r\n", Zero/binary>>,                          "hello",            5},
+             {<<"5\r\nhello\r\n5\r\n worl\r\n2\r\nd!\r\n", Zero/binary>>, <<"hello world!">>, 5},
+             {<<"5\r\nhello\r\n5\r\n worl\r\n2\r\nd!\r\n", Zero/binary>>, "hello world!",     5}
+            ],
+    Failures =
+        [{Body, N, Expect, Got}
+         || {Expect, Body, N} <- Cases,
+            Got <- [iolist_to_binary(chunk_body(Body, N))],
+            Got =/= Expect
+        ],
+    % We expect fun tuples to pass through
+    Fun = fun(_) -> eof end,
+    PassthroughOk = chunk_body(Fun, 1024) =:= Fun andalso chunk_body({Fun, foo}, 1024) =:= {Fun, foo},
+    case {Failures, PassthroughOk} of
+        {[], true} -> success;
+        {_, _}     -> {failed, Failures, {passthrough_ok, PassthroughOk}}
+    end.
 
 do_trace(Fmt, Args) ->
     do_trace(get(my_trace_flag), Fmt, Args).


### PR DESCRIPTION
Inspired by https://github.com/cmullaparthi/ibrowse/issues/74 tried running `ERL_COMPILER_OPTIONS=bin_opt_info` with OTP 27.

From the list the only good candidate for optimization seems to be chunk_request_body, and to get it to optimize had break out the binary case into a separate function then use a `case` there.

[1] https://erlang.org/documentation/doc-15.0-rc1/doc/system/binaryhandling.html

Before
```
rm ebin/ibrowse_http_client.beam ; ERL_COMPILER_OPTIONS=bin_opt_info make 2>&1
rm: ebin/ibrowse_http_client.beam: No such file or directory
 ERLC   ibrowse_lib.erl ibrowse.erl ibrowse_http_client.erl ibrowse_sup.erl ibrowse_app.erl ibrowse_lb.erl ibrowse_socks5.erl
compile: warnings being treated as errors
src/ibrowse_http_client.erl:1231: BINARY CREATED: binary is used in call to chunk_request_body/3 which doesn't support context reuse
% 1231|     chunk_request_body(Rest, ChunkSize, [Chunk | Acc]);

src/ibrowse_http_client.erl:1231: NOT OPTIMIZED: binary used in call to chunk_request_body/3, where binary is used in '=='/2 before being matched
% 1231|     chunk_request_body(Rest, ChunkSize, [Chunk | Acc]);
```

After
```
% rm ebin/ibrowse_http_client.beam ; ERL_COMPILER_OPTIONS=bin_opt_info make 2>&1
rm: ebin/ibrowse_http_client.beam: No such file or directory
 ERLC   ibrowse_lib.erl ibrowse.erl ibrowse_http_client.erl ibrowse_sup.erl ibrowse_app.erl ibrowse_lb.erl ibrowse_socks5.erl
compile: warnings being treated as errors
src/ibrowse_http_client.erl:1243: OPTIMIZED: match context reused
% 1243|             chunk_binary_body(Rest, ChunkSize, [Chunk | Acc]);

src/ibrowse_http_client.erl:1248: OPTIMIZED: match context reused
% 1248|             BodySize = byte_size(Body),
```

I don't know if we had any tests for chunk encoding so added some (such that they run in CI as well).