### PR TITLE
Replace `catch` with `try-catch` to fix the compilation error in OTP-29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
         os:
           - ubuntu-latest
         otp:
+          - "29"
           - "28"
           - "27"
           - "26"
           - "25"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: make
       - run: make unit_tests
- 

--- a/include/ibrowse.hrl
+++ b/include/ibrowse.hrl
@@ -23,4 +23,17 @@
 -define(CONF_TABLE, ibrowse_conf).
 -define(STREAM_TABLE, ibrowse_stream).
 
+-define(TRY_CATCH(F, A), ?TRY_CATCH(erlang, apply, [F, A])).
+-define(TRY_CATCH(M, F, A),
+    (fun() ->
+        try
+            apply(M, F, A)
+        catch
+            throw:__Term -> __Term;
+            exit:__Reason -> {'EXIT', __Reason};
+            error:__Reason:__Stacktrace -> {'EXIT', {__Reason, __Stacktrace}}
+        end
+     end)()
+).
+
 -endif.

--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -102,7 +102,11 @@
          show_dest_status/1,
          show_dest_status/2,
          get_metrics/0,
-         get_metrics/2
+         get_metrics/2,
+         import_config/0,
+         import_config/1,
+         apply_config/1,
+         insert_config/1
         ]).
 
 -ifdef(debug).
@@ -143,11 +147,11 @@ start() ->
 
 %% @doc Stop the ibrowse process. Useful when testing using the shell.
 stop() ->
-    case catch gen_server:call(ibrowse, stop) of
-        {'EXIT',{noproc,_}} ->
-            ok;
-        Res ->
-            Res
+    try
+        gen_server:call(ibrowse, stop)
+    catch
+        exit:{noproc, _} -> ok;
+        exit:Reason -> {'EXIT', Reason}
     end.
 
 %% @doc This is the basic function to send a HTTP request.
@@ -339,7 +343,7 @@ send_req(Url, Headers, Method, Body, Options) ->
 %% @spec send_req(Url, Headers::headerList(), Method::method(), Body::body(), Options::optionList(), Timeout) -> response()
 %% Timeout = integer() | infinity
 send_req(Url, Headers, Method, Body, Options, Timeout) ->
-    case catch parse_url(Url) of
+    try parse_url(Url) of
         #url{host = Host,
              port = Port,
              protocol = Protocol} = Parsed_url ->
@@ -355,12 +359,15 @@ send_req(Url, Headers, Method, Body, Options, Timeout) ->
                     true -> {get_value(ssl_options, Options_1, []), true}
                 end,
             try_routing_request(Lb_pid, Parsed_url,
-                                Max_sessions, 
+                                Max_sessions,
                                 Max_pipeline_size,
-                                {SSLOptions, IsSSL}, 
+                                {SSLOptions, IsSSL},
                                 Headers, Method, Body, Options_1, Timeout, Timeout, os:timestamp(), Max_attempts, 0);
         Err ->
             {error, {url_parsing_failed, Err}}
+    catch
+        _:Reason ->
+            {error, {url_parsing_failed, Reason}}
     end.
 
 lb_pid(Host, Port, Url) ->
@@ -503,36 +510,22 @@ set_download_dir(Dir) ->
     gen_server:call(?MODULE, {set_config_value, download_dir, Dir}).
 
 do_send_req(Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout) ->
-    case catch ibrowse_http_client:send_req(Conn_Pid, Parsed_url,
-                                            Headers, Method, ensure_bin(Body),
-                                            Options, Timeout) of
-        {'EXIT', {timeout, _}} ->
-            P_info = case catch erlang:process_info(Conn_Pid, [messages, message_queue_len, backtrace]) of
-                            [_|_] = Conn_Pid_info_list ->
-                                Conn_Pid_info_list;
-                            _ ->
-                                process_info_not_available
-                        end,
-            log_msg("{ibrowse_http_client, send_req, ~1000.p} gen_server call timeout.~nProcess info: ~p~n",
-                    [[Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout], P_info]),
-            {error, req_timedout};
-        {'EXIT', {normal, _}} = Ex_rsn ->
-            log_msg("{ibrowse_http_client, send_req, ~1000.p} gen_server call got ~1000.p~n",
-                    [[Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout], Ex_rsn]),
-            {error, req_timedout};
-        {error, X} when X == connection_closed;
-                        X == {send_failed, {error, enotconn}};
-                        X == {send_failed,{error,einval}};
-                        X == {send_failed,{error,closed}};
-                        X == connection_closing;
-                        ((X == connection_closed_no_retry) andalso ((Method == get) orelse (Method == head))) ->
+    try ibrowse_http_client:send_req(Conn_Pid, Parsed_url,
+                                     Headers, Method, ensure_bin(Body),
+                                     Options, Timeout) of
+        {error, X} when
+            X == connection_closed;
+            X == {send_failed, {error, enotconn}};
+            X == {send_failed, {error, einval}};
+            X == {send_failed, {error, closed}};
+            X == connection_closing;
+            ((X == connection_closed_no_retry) andalso ((Method == get) orelse (Method == head)))
+            ->
             {error, sel_conn_closed};
         {error, connection_closed_no_retry} ->
             {error, connection_closed};
         {error, {'EXIT', {noproc, _}}} ->
             {error, sel_conn_closed};
-        {'EXIT', Reason} ->
-            {error, {'EXIT', Reason}};
         {ok, St_code, Headers, Body} = Ret when is_binary(Body) ->
             case get_value(response_format, Options, list) of
                 list ->
@@ -549,6 +542,35 @@ do_send_req(Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout) ->
             end;
         Ret ->
             Ret
+    catch
+        throw:Term ->
+            Term;
+        exit:{timeout, _} ->
+            P_info =
+                try erlang:process_info(Conn_Pid, [messages, message_queue_len, backtrace]) of
+                    [_ | _] = Conn_Pid_info_list ->
+                        Conn_Pid_info_list;
+                    _ ->
+                        process_info_not_available
+                catch
+                    _:_ ->
+                        process_info_not_available
+                end,
+            log_msg(
+                "{ibrowse_http_client, send_req, ~1000.p} gen_server call timeout.~nProcess info: ~p~n",
+                [[Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout], P_info]
+            ),
+            {error, req_timedout};
+        exit:{normal, _} = Ex_rsn ->
+            log_msg(
+                "{ibrowse_http_client, send_req, ~1000.p} gen_server call got ~1000.p~n",
+                [[Conn_Pid, Parsed_url, Headers, Method, Body, Options, Timeout], Ex_rsn]
+            ),
+            {error, req_timedout};
+        exit:Reason ->
+            {error, {'EXIT', Reason}};
+        error:Reason:Stacktrace ->
+            {error, {'EXIT', {Reason, Stacktrace}}}
     end.
 
 ensure_bin(L) when is_list(L)                     -> list_to_binary(L);
@@ -620,7 +642,7 @@ send_req_direct(Conn_pid, Url, Headers, Method, Body, Options) ->
 %% @doc Same as send_req/6 except that the first argument is the PID
 %% returned by spawn_worker_process/2 or spawn_link_worker_process/2
 send_req_direct(Conn_pid, Url, Headers, Method, Body, Options, Timeout) ->
-    case catch parse_url(Url) of
+    try parse_url(Url) of
         #url{host = Host,
              port = Port} = Parsed_url ->
             Options_1 = merge_options(Host, Port, Options),
@@ -632,18 +654,21 @@ send_req_direct(Conn_pid, Url, Headers, Method, Body, Options, Timeout) ->
             end;
         Err ->
             {error, {url_parsing_failed, Err}}
+    catch
+        _:Reason ->
+            {error, {url_parsing_failed, Reason}}
     end.
 
 %% @doc Tell ibrowse to stream the next chunk of data to the
 %% caller. Should be used in conjunction with the
 %% <code>stream_to</code> option
 %% @spec stream_next(Req_id :: req_id()) -> ok | {error, unknown_req_id}
-stream_next(Req_id) ->    
+stream_next(Req_id) ->
     case ets:lookup(ibrowse_stream, {req_id_pid, Req_id}) of
         [] ->
             {error, unknown_req_id};
         [{_, Pid}] ->
-            catch Pid ! {stream_next, Req_id},
+            ?TRY_CATCH(fun erlang:send/2, [Pid, {stream_next, Req_id}]),
             ok
     end.
 
@@ -653,12 +678,12 @@ stream_next(Req_id) ->
 %% the connection which is serving this Req_id will be aborted, and an
 %% error returned.
 %% @spec stream_close(Req_id :: req_id()) -> ok | {error, unknown_req_id}
-stream_close(Req_id) ->    
+stream_close(Req_id) ->
     case ets:lookup(ibrowse_stream, {req_id_pid, Req_id}) of
         [] ->
             {error, unknown_req_id};
         [{_, Pid}] ->
-            catch Pid ! {stream_close, Req_id},
+            ?TRY_CATCH(fun erlang:send/2, [Pid, {stream_close, Req_id}]),
             ok
     end.
 
@@ -757,12 +782,15 @@ get_metrics(Host, Port) ->
         [] ->
             no_active_processes;
         [#lb_pid{pid = Lb_pid, ets_tid = Tid}] ->
-            MsgQueueSize = case (catch process_info(Lb_pid, message_queue_len)) of
-			       {message_queue_len, Msg_q_len} ->
-				   Msg_q_len;
-			       _ ->
-				   -1
-			   end,
+            MsgQueueSize =
+                try process_info(Lb_pid, message_queue_len) of
+                    {message_queue_len, Msg_q_len} ->
+                        Msg_q_len;
+                    _ ->
+                        -1
+                catch
+                    _:_ -> -1
+                end,
             case Tid of
                 undefined ->
                     {Lb_pid, MsgQueueSize, undefined, 0, {{0, 0}, {0, 0}}};
@@ -924,19 +952,19 @@ handle_call({set_config_value, Key, Val}, _From, State) ->
     {reply, ok, State};
 
 handle_call(rescan_config, _From, State) ->
-    Ret = (catch import_config()),
+    Ret = ?TRY_CATCH(fun ?MODULE:import_config/0, []),
     {reply, Ret, State};
 
 handle_call({rescan_config, File}, _From, State) ->
-    Ret = (catch import_config(File)),
+    Ret = ?TRY_CATCH(fun ?MODULE:import_config/1, [File]),
     {reply, Ret, State};
 
 handle_call({rescan_config_terms, Terms}, _From, State) ->
-    Ret = (catch apply_config(Terms)),
+    Ret = ?TRY_CATCH(fun ?MODULE:apply_config/1, [Terms]),
     {reply, Ret, State};
 
 handle_call({add_config_terms, Terms}, _From, State) ->
-    Ret = (catch insert_config(Terms)),
+    Ret = ?TRY_CATCH(fun ?MODULE:insert_config/1, [Terms]),
     {reply, Ret, State};
 
 handle_call(Request, _From, State) ->
@@ -969,11 +997,11 @@ handle_info(all_trace_off, State) ->
                       false ->
                           ok;
                       true ->
-                          catch Pid ! {trace, false}
+                          ?TRY_CATCH(fun erlang:send/2, [Pid, {trace, false}])
                   end;
              (_, Acc) ->
                   Acc
-          end,
+           end,
     ets:foldl(Fun, undefined, ibrowse_lb),
     ets:select_delete(ibrowse_conf, [{{ibrowse_conf,{trace,'$1','$2'},true},[],['true']}]),
     {noreply, State};
@@ -986,7 +1014,7 @@ handle_info({trace, Bool, Host, Port}, State) ->
     Fun = fun(#lb_pid{host_port = {H, P}, pid = Pid}, _)
              when H == Host,
                   P == Port ->
-                  catch Pid ! {trace, Bool};
+                  ?TRY_CATCH(fun erlang:send/2, [Pid, {trace, Bool}]);
              (_, Acc) ->
                   Acc
           end,

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -103,23 +103,27 @@ start_link(Args, Options) ->
     gen_server:start_link(?MODULE, Args, Options).
 
 stop(Conn_pid) ->
-    case catch gen_server:call(Conn_pid, stop) of
-        {'EXIT', {timeout, _}} ->
+    try gen_server:call(Conn_pid, stop) of
+        _ ->
+            ok
+    catch
+        exit:{timeout, _} ->
             exit(Conn_pid, kill),
             ok;
-        _ ->
+        _:_ ->
             ok
     end.
 
 send_req(Conn_Pid, Url, Headers, Method, Body, Options, Timeout) ->
-    case catch gen_server:call(Conn_Pid,
-                               {send_req, {Url, Headers, Method, Body, Options, Timeout}}, Timeout) of
-        {'EXIT', {timeout, _}} ->
+    try gen_server:call(Conn_Pid,
+                        {send_req, {Url, Headers, Method, Body, Options, Timeout}}, Timeout)
+    catch
+        exit:{timeout, _} ->
             {error, req_timedout};
-        {'EXIT', {noproc, _}} ->
+        exit:{noproc, _} ->
             {error, connection_closed};
-        Res ->
-            Res
+        exit:Reason ->
+            {'EXIT', Reason}
     end.
 
 %%====================================================================
@@ -146,10 +150,13 @@ init({Lb_Tid, #url{host = Host, port = Port}, {SSLOptions, Is_ssl}}) ->
     {ok, set_inac_timer(State)};
 init(Url) when is_list(Url) ->
     maybe_trap_exits(),
-    case catch ibrowse_lib:parse_url(Url) of
+    try ibrowse_lib:parse_url(Url) of
         #url{protocol = Protocol} = Url_rec ->
             init({undefined, Url_rec, {[], Protocol == https}});
-        {'EXIT', _} ->
+        _ ->
+            {error, invalid_url}
+    catch
+        _:_ ->
             {error, invalid_url}
     end;
 init({Host, Port}) ->
@@ -271,7 +278,7 @@ handle_info({req_timedout, From}, #state{reqs = Reqs} = State) ->
         false ->
             {noreply, State};
         #request{stream_to = StreamTo, req_id = ReqId} ->
-            catch StreamTo ! {ibrowse_async_response_timeout, ReqId},
+            ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_response_timeout, ReqId}]),
             State_1 = State#state{proc_state = ?dead_proc_walking},
             shutting_down(State_1),
             Reqs_1 = lists:filter(fun(#request{from = X_from}) ->
@@ -312,7 +319,7 @@ handle_info(Info, State) ->
 terminate(_Reason, #state{lb_ets_tid = Tid} = State) ->
     do_close(State),
     shutting_down(State),
-    (catch ets:select_delete(Tid, [{{{'_','_','$1'},'_'},[{'==','$1',{const,self()}}],[true]}])),
+    ?TRY_CATCH(fun ets:select_delete/2, [Tid, [{{{'_','_','$1'},'_'},[{'==','$1',{const,self()}}],[true]}]]),
     ok.
 
 %%--------------------------------------------------------------------
@@ -661,14 +668,14 @@ do_connect(Host, Port, Options, _State, Timeout) ->
     %% Check for connect_to override and remove from options
     Host1 = get_value(connect_to, Options, Host),
     Options1 = proplists:delete(connect_to, Options),
-    
+
     Socks5Host = get_value(socks5_host, Options1, undefined),
     Sock_options = get_sock_options(Host, Options1, []),
     case Socks5Host of
-      undefined ->
-        gen_tcp:connect(Host1, Port, Sock_options, Timeout);
-      _ ->
-        catch ibrowse_socks5:connect(Host1, Port, Options1, Sock_options, Timeout)
+        undefined ->
+            gen_tcp:connect(Host1, Port, Sock_options, Timeout);
+        _ ->
+            ?TRY_CATCH(fun ibrowse_socks5:connect/5, [Host1, Port, Options1, Sock_options, Timeout])
     end.
 
 get_sock_options(Host, Options, SSLOptions) ->
@@ -822,9 +829,9 @@ do_close(#state{socket = Sock,
                 is_ssl = true,
                 use_proxy = true,
                 proxy_tunnel_setup = Pts
-               }) when Pts /= done ->  catch gen_tcp:close(Sock);
-do_close(#state{socket = Sock, is_ssl = true})  ->  catch ssl:close(Sock);
-do_close(#state{socket = Sock, is_ssl = false}) ->  catch gen_tcp:close(Sock).
+               }) when Pts /= done -> ?TRY_CATCH(fun gen_tcp:close/1, [Sock]);
+do_close(#state{socket = Sock, is_ssl = true})  -> ?TRY_CATCH(fun ssl:close/1, [Sock]);
+do_close(#state{socket = Sock, is_ssl = false}) -> ?TRY_CATCH(fun gen_tcp:close/1, [Sock]).
 
 active_once(#state{cur_req = #request{caller_controls_socket = true}}) ->
     ok;
@@ -1038,7 +1045,7 @@ send_req_1(From,
                                 false ->
                                     ok;
                                 true ->
-                                    catch StreamTo ! {ibrowse_async_raw_req, Raw_req}
+                                    ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_raw_req, Raw_req}])
                             end
                     end,
                     State_4 = set_inac_timer(State_3),
@@ -1400,7 +1407,7 @@ parse_response(Data, #state{reply_buffer = Acc, reqs = Reqs,
                                                      {stat_code, StatCode}, Headers}}),
                     {error, content_length_undefined};
                 V ->
-                    case catch list_to_integer(V) of
+                    try list_to_integer(V) of
                         V_1 when is_integer(V_1), V_1 >= 0 ->
                             send_async_headers(ReqId, StreamTo, Give_raw_headers, State_1),
                             do_trace("Recvd Content-Length of ~p~n", [V_1]),
@@ -1417,6 +1424,12 @@ parse_response(Data, #state{reply_buffer = Acc, reqs = Reqs,
                                     State_3
                             end;
                         _ ->
+                            fail_pipelined_requests(State_1,
+                                                    {error, {content_length_undefined,
+                                                             {stat_code, StatCode}, Headers}}),
+                            {error, content_length_undefined}
+                    catch
+                        _:_ ->
                             fail_pipelined_requests(State_1,
                                                     {error, {content_length_undefined,
                                                              {stat_code, StatCode}, Headers}}),
@@ -1974,9 +1987,9 @@ send_async_headers(ReqId, StreamTo, Give_raw_headers,
     {Headers_1, Raw_headers_1} = maybe_add_custom_headers(Status_line, Headers, Raw_headers, Opts),
     case Give_raw_headers of
         false ->
-            catch StreamTo ! {ibrowse_async_headers, ReqId, StatCode, Headers_1};
+            ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_headers, ReqId, StatCode, Headers_1}]);
         true ->
-            catch StreamTo ! {ibrowse_async_headers, ReqId, Status_line, Raw_headers_1}
+            ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_headers, ReqId, Status_line, Raw_headers_1}])
     end.
 
 maybe_add_custom_headers(Status_line, Headers, Raw_headers, Opts) ->
@@ -2030,9 +2043,9 @@ do_reply(#state{prev_req_id = Prev_req_id} = State,
             ok;
         _ ->
             Body_1 = format_response_data(Resp_format, Body),
-            catch StreamTo ! {ibrowse_async_response, ReqId, Body_1}
+            ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_response, ReqId, Body_1}])
     end,
-    catch StreamTo ! {ibrowse_async_response_end, ReqId},
+    ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_response_end, ReqId}]),
     %% We don't want to delete the Req-id to Pid mapping straight away
     %% as the client may send a stream_next message just while we are
     %% sending back this ibrowse_async_response_end message. If we
@@ -2048,14 +2061,14 @@ do_reply(#state{prev_req_id = Prev_req_id} = State,
 do_reply(State, _From, StreamTo, ReqId, Resp_format, Msg) ->
     State_1 = dec_pipeline_counter(State),
     Msg_1 = format_response_data(Resp_format, Msg),
-    catch StreamTo ! {ibrowse_async_response, ReqId, Msg_1},
+    ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_response, ReqId, Msg_1}]),
     State_1.
 
 do_interim_reply(undefined, _, _ReqId, _Msg) ->
     ok;
 do_interim_reply(StreamTo, Response_format, ReqId, Msg) ->
     Msg_1 = format_response_data(Response_format, Msg),
-    catch StreamTo ! {ibrowse_async_response, ReqId, Msg_1}.
+    ?TRY_CATCH(fun erlang:send/2, [StreamTo, {ibrowse_async_response, ReqId, Msg_1}]).
 
 do_error_reply(#state{reqs = Reqs, tunnel_setup_queue = Tun_q} = State, Err) ->
     ReqList = queue:to_list(Reqs),
@@ -2148,7 +2161,7 @@ shutting_down(#state{lb_ets_tid = undefined}) ->
     ok;
 shutting_down(#state{lb_ets_tid = Tid,
                      cur_pipeline_size = _Sz}) ->
-    (catch ets:select_delete(Tid, [{{{'_', '_', '$1'},'_'},[{'==','$1',{const,self()}}],[true]}])).
+    ?TRY_CATCH(fun ets:select_delete/2, [Tid, [{{{'_', '_', '$1'},'_'},[{'==','$1',{const,self()}}],[true]}]]).
 
 inc_pipeline_counter(#state{is_closing = true} = State) ->
     State;
@@ -2162,12 +2175,12 @@ dec_pipeline_counter(#state{cur_pipeline_size = Pipe_sz,
                             proc_state        = Proc_state} = State) when Tid /= undefined,
                                                                           Proc_state /= ?dead_proc_walking ->
     Ts = os:timestamp(),
-    catch ets:insert(Tid, {{Pipe_sz - 1, os:timestamp(), self()}, []}),
-    (catch ets:select_delete(Tid, [{{{'_', '$2', '$1'},'_'},
-                                    [{'==', '$1', {const,self()}},
-                                     {'<',  '$2', {const,Ts}}
-                                    ],
-                                    [true]}])),
+    ?TRY_CATCH(fun ets:insert/2, [Tid, {{Pipe_sz - 1, os:timestamp(), self()}, []}]),
+    ?TRY_CATCH(fun ets:select_delete/2, [Tid, [{{{'_', '$2', '$1'},'_'},
+                                                [{'==', '$1', {const,self()}},
+                                                 {'<',  '$2', {const,Ts}}
+                                                ],
+                                                [true]}]]),
     State#state{cur_pipeline_size = Pipe_sz - 1};
 dec_pipeline_counter(State) ->
     State.

--- a/src/ibrowse_lb.erl
+++ b/src/ibrowse_lb.erl
@@ -90,11 +90,11 @@ spawn_connection(Lb_pid, Url,
 		    {spawn_connection, Url, Max_sessions, Max_pipeline_size, SSL_options, Process_options}).
 
 stop(Lb_pid) ->
-    case catch gen_server:call(Lb_pid, stop) of
-        {'EXIT', {timeout, _}} ->
-            exit(Lb_pid, kill);
-        ok ->
-            ok
+    try
+        gen_server:call(Lb_pid, stop)
+    catch
+        exit:{timeout, _} -> exit(Lb_pid, kill);
+        exit:Reason -> {'EXIT', Reason}
     end.
 %%--------------------------------------------------------------------
 %% Function: handle_call/3
@@ -165,7 +165,7 @@ handle_info({trace, Bool}, #state{ets_tid = undefined} = State) ->
 
 handle_info({trace, Bool}, #state{ets_tid = Tid} = State) ->
     ets:foldl(fun({{_, Pid}, _}, Acc) when is_pid(Pid) ->
-		      catch Pid ! {trace, Bool},
+              ?TRY_CATCH(fun erlang:send/2, [Pid, {trace, Bool}]),
 		      Acc;
 		 (_, Acc) ->
 		      Acc
@@ -194,7 +194,7 @@ handle_info(_Info, State) ->
 %% Returns: any (ignored by gen_server)
 %%--------------------------------------------------------------------
 terminate(_Reason, #state{host = Host, port = Port, ets_tid = Tid} = _State) ->
-    catch ets:delete(ibrowse_lb, {Host, Port}),
+    ?TRY_CATCH(fun ets:delete/2, [ibrowse_lb, {Host, Port}]),
     stop_all_conn_procs(Tid),
     ok.
 

--- a/src/ibrowse_lib.erl
+++ b/src/ibrowse_lib.erl
@@ -62,11 +62,13 @@ d2h(N) when N<10 -> N+$0;
 d2h(N) -> N+$a-10.
 
 decode_rfc822_date(String) when is_list(String) ->
-    case catch decode_rfc822_date_1(string:tokens(String, ", \t\r\n")) of
-        {'EXIT', _} ->
-            {error, invalid_date};
-        Res ->
-            Res
+    try
+        decode_rfc822_date_1(string:tokens(String, ", \t\r\n"))
+    catch
+        throw:Term ->
+            Term;
+        _:_ ->
+            {error, invalid_date}
     end.
 
 % TODO: Have to handle the Zone
@@ -422,7 +424,7 @@ log_msg(Fmt, Args) ->
     end.
 
 log_msg(M, F, Fmt, Args) ->
-    catch apply(M, F, [Fmt, Args]).
+    ?TRY_CATCH(M, F, [Fmt, Args]).
 
 -ifdef(EUNIT).
 

--- a/test/ibrowse_load_test.erl
+++ b/test/ibrowse_load_test.erl
@@ -32,10 +32,14 @@ start_1(Num_workers, Num_requests, Max_sess) ->
     application:start(ibrowse),
     application:set_env(ibrowse, inactivity_timeout, 5000),
     Ulimit = os:cmd("ulimit -n"),
-    case catch list_to_integer(string:strip(Ulimit, right, $\n)) of
+    try list_to_integer(string:strip(Ulimit, right, $\n)) of
         X when is_integer(X), X > 3000 ->
             ok;
         X ->
+            io:format("Load test not starting. {insufficient_value_for_ulimit, ~p}~n", [X]),
+            exit({insufficient_value_for_ulimit, X})
+    catch
+        _:X ->
             io:format("Load test not starting. {insufficient_value_for_ulimit, ~p}~n", [X]),
             exit({insufficient_value_for_ulimit, X})
     end,
@@ -108,11 +112,11 @@ spawn_workers(0, _Num_requests, _Parent, Acc) ->
     lists:reverse(Acc);
 spawn_workers(Num_workers, Num_requests, Parent, Acc) ->
     Pid_ref = spawn_monitor(fun() ->
-                                    case catch worker_loop(Parent, Num_requests) of
-                                        {'EXIT', Rsn} ->
-                                            io:format("Worker crashed with reason: ~p~n", [Rsn]);
-                                        _ ->
-                                            ok
+                                    try worker_loop(Parent, Num_requests) of
+                                        _ -> ok
+                                    catch
+                                        throw:_ -> ok;
+                                        _:Rsn -> io:format("Worker crashed with reason: ~p~n", [Rsn])
                                     end
                             end),
     spawn_workers(Num_workers - 1, Num_requests, Parent, [Pid_ref | Acc]).
@@ -184,10 +188,12 @@ worker_loop(Parent, N) ->
     worker_loop(Parent, N - 1).
 
 update_unknown_counter(Counter, Inc_val) ->
-    case catch ets:update_counter(?ibrowse_load_test_counters, Counter, Inc_val) of
-        {'EXIT', _} ->
+    try ets:update_counter(?ibrowse_load_test_counters, Counter, Inc_val) of
+        _ -> ok
+    catch
+        throw:_ ->
+            ok;
+        _:_ ->
             ets:insert_new(?ibrowse_load_test_counters, {Counter, 0}),
-            update_unknown_counter(Counter, Inc_val);
-        _ ->
-            ok
+            update_unknown_counter(Counter, Inc_val)
     end.

--- a/test/ibrowse_test.erl
+++ b/test/ibrowse_test.erl
@@ -232,8 +232,8 @@ spawn_workers(Url, NumWorkers, NumReqsPerWorker) ->
 do_wait(Url) ->
     receive
 	{'EXIT', _, normal} ->
-            catch ibrowse:show_dest_status(Url),
-            catch ibrowse:show_dest_status(),
+            ?TRY_CATCH(fun ibrowse:show_dest_status/1, [Url]),
+            ?TRY_CATCH(fun ibrowse:show_dest_status/0, []),
 	    do_wait(Url);
 	{'EXIT', Pid, Reason} ->
 	    ets:delete(pid_table, Pid),
@@ -248,8 +248,8 @@ do_wait(Url) ->
 		0 ->
 		    done;
 		_ ->
-                    catch ibrowse:show_dest_status(Url),
-                    catch ibrowse:show_dest_status(),
+                    ?TRY_CATCH(fun ibrowse:show_dest_status/1, [Url]),
+                    ?TRY_CATCH(fun ibrowse:show_dest_status/0, []),
 		    do_wait(Url)
 	    end
     end.
@@ -320,7 +320,7 @@ unit_tests(Options, Test_list) ->
     application:start(asn1),
     application:start(public_key),
     application:start(ssl),
-    (catch ibrowse_test_server:start_server(8181, tcp)),
+    ?TRY_CATCH(fun ibrowse_test_server:start_server/2, [8181, tcp]),
     application:start(ibrowse),
     Options_1 = Options ++ [{connect_timeout, 5000}],
     Test_timeout = proplists:get_value(test_timeout, Options, 60000),
@@ -334,7 +334,7 @@ unit_tests(Options, Test_list) ->
 	    exit(Pid, kill),
 	    io:format("Timed out waiting for tests to complete~n", [])
     end,
-    catch ibrowse_test_server:stop_server(8181),
+    ?TRY_CATCH(fun ibrowse_test_server:stop_server/1, [8181]),
     error_logger:tty(true),
     ok.
 
@@ -498,12 +498,12 @@ maybe_stream_next(Req_id, Options) ->
 
 execute_req(local_test_fun, Method, Args) ->
     reset_ibrowse(),
-    Result = (catch apply(?MODULE, Method, Args)),
+    Result = ?TRY_CATCH(?MODULE, Method, Args),
     io:format("     ~-54.54w: ", [Method]),
     io:format("~p~n", [Result]);
 execute_req(Url, Method, Options) ->
     io:format("~7.7w, ~50.50s: ", [Method, Url]),
-    Result = (catch ibrowse:send_req(Url, [], Method, [], Options)),
+    Result = ?TRY_CATCH(fun ibrowse:send_req/5, [Url, [], Method, [], Options]),
     case Result of
 	{ok, SCode, _H, _B} ->
 	    io:format("Status code: ~p~n", [SCode]);
@@ -747,7 +747,7 @@ test_retry_of_requests(Url, Timeout) ->
     Parent = self(),
     Pids = lists:map(fun(_) ->
                         spawn(fun() ->
-                                 Res = (catch ibrowse:send_req(Url, [], get, [], [], Timeout)),
+                                 Res = ?TRY_CATCH(fun ibrowse:send_req/6, [Url, [], get, [], [], Timeout]),
                                  Parent ! {self(), Res}
                               end)
                      end, lists:seq(1,10)),

--- a/test/ibrowse_test_server.erl
+++ b/test/ibrowse_test_server.erl
@@ -11,6 +11,8 @@
          get_conn_pipeline_depth/0
         ]).
 
+-include_lib("ibrowse/include/ibrowse.hrl").
+
 -record(request, {method, uri, version, headers = [], body = [], state}).
 
 -define(dec2hex(X), erlang:integer_to_list(X, 16)).
@@ -51,7 +53,7 @@ start_server(Port, Sock_type) ->
     ibrowse_socks_server:start(8383, 2). %% Username/Password auth
 
 stop_server(Port) ->
-    catch server_proc_name(Port) ! stop,
+    ?TRY_CATCH(fun erlang:send/2, [server_proc_name(Port), stop]),
     ibrowse_socks_server:stop(8282),
     ibrowse_socks_server:stop(8383),
     timer:sleep(2000),  % wait for server to receive msg and unregister
@@ -104,12 +106,12 @@ accept_loop(Sock, Sock_type) ->
     end.
 
 connection(Conn, Sock_type) ->
-    catch ets:insert(?CONN_PIPELINE_DEPTH, {self(), 0}),
+    ?TRY_CATCH(fun ets:insert/2, [?CONN_PIPELINE_DEPTH, {self(), 0}]),
     try
 	inet:setopts(Conn, [{packet, http}, {active, true}]),
         server_loop(Conn, Sock_type, #request{})
     after
-        catch ets:delete(?CONN_PIPELINE_DEPTH, self())
+        ?TRY_CATCH(fun ets:delete/2, [?CONN_PIPELINE_DEPTH, self()])
     end.
 
 set_controlling_process(Sock, tcp, Pid) ->
@@ -125,7 +127,7 @@ setopts(Sock, ssl, Opts) ->
 server_loop(Sock, Sock_type, #request{headers = Headers} = Req) ->
     receive
         {http, Sock, {http_request, HttpMethod, HttpUri, HttpVersion}} ->
-            catch ets:update_counter(?CONN_PIPELINE_DEPTH, self(), 1),
+            ?TRY_CATCH(fun ets:update_counter/3, [?CONN_PIPELINE_DEPTH, self(), 1]),
             server_loop(Sock, Sock_type, Req#request{method = HttpMethod,
                                                      uri = HttpUri,
                                                      version = HttpVersion});
@@ -140,7 +142,7 @@ server_loop(Sock, Sock_type, #request{headers = Headers} = Req) ->
 		collect_body ->
 		    server_loop(Sock, Sock_type, Req#request{state = collect_body});
                 _ ->
-                    catch ets:update_counter(?CONN_PIPELINE_DEPTH, self(), -1)
+                    ?TRY_CATCH(fun ets:update_counter/3, [?CONN_PIPELINE_DEPTH, self(), -1])
             end,
             server_loop(Sock, Sock_type, #request{});
         {http, Sock, {http_error, Packet}} when Req#request.state == collect_body ->


### PR DESCRIPTION
- CI: 
  - Add `OTP-29` to GitHub Actions to run tests.
  - Update actions/checkout from `v5` to `v6`.

- Replace `catch` with `try-catch` to fix the compilation error in OTP-29:

```bash
$ make
...
src/ibrowse_lib.erl:65:10: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   65|     case catch decode_rfc822_date_1(string:tokens(String, ", \t\r\n")) of
%     |
...
```

