### PR TITLE
CI: Run tests against OTP-29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         otp:
+          - "29"
           - "28"
           - "27"
           - "26"
@@ -23,4 +24,3 @@ jobs:
       - uses: actions/checkout@v5
       - run: make
       - run: make unit_tests
- 

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,9 @@
 {erl_opts, [
-	   debug_info,
-	   warnings_as_errors,
-	   warn_unused_vars,
-	   nowarn_shadow_vars,
-	   warn_unused_import
-	   ]}.
+    debug_info,
+    warn_unused_vars,
+    nowarn_shadow_vars,
+    warn_unused_import
+]}.
 % rebar 2
 {require_min_otp_vsn, "25"}.
 % rebar 3

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,9 @@
 {erl_opts, [
     debug_info,
-    warn_unused_vars,
+    nowarn_deprecated_catch,
     nowarn_shadow_vars,
-    warn_unused_import
+    warn_unused_import,
+    warn_unused_vars
 ]}.
 % rebar 2
 {require_min_otp_vsn, "25"}.


### PR DESCRIPTION
- CI: Run tests against OTP-29
- Remove `warnings_as_errors` to pass the CI in OTP-29
- Add `nowarn_deprecated_catch` to pass the CI in OTP-29